### PR TITLE
Allow driver specific table options on create_table.

### DIFF
--- a/classes/Drivers/Driver.php
+++ b/classes/Drivers/Driver.php
@@ -70,9 +70,10 @@ abstract class Drivers_Driver
 	 * @param	array
 	 * @param	mixed    Primary key, false if not desired, not specified sets to 'id' column.
 	 *                   Will be set to auto_increment by default.
+   * @param mixed    Driver specific table options.  Array of options, or false if none.
 	 * @return	boolean
 	 */
-	abstract public function create_table($table_name, $fields, $primary_key = TRUE);
+	abstract public function create_table($table_name, $fields, $primary_key = TRUE, $table_options = FALSE);
 
 	/**
 	 * Drop a table

--- a/classes/Drivers/Mysql.php
+++ b/classes/Drivers/Mysql.php
@@ -12,8 +12,7 @@ class Drivers_Mysql extends Drivers_Driver
 	{
 		$this->db->query($this->group, 'COMMIT', false);
 	}
-	
-	public function create_table($table_name, $fields, $primary_key = TRUE)
+	public function create_table($table_name, $fields, $primary_key = TRUE, $table_options = FALSE)
 	{
 		$sql = "CREATE TABLE `$table_name` (";
 
@@ -51,6 +50,32 @@ class Drivers_Mysql extends Drivers_Driver
 		}
 
 		$sql .= ")";
+
+    // http://dev.mysql.com/doc/refman/5.5/en/create-table.html
+    if (is_array($table_options))
+    {
+      if ( isset( $table_options['engine'] ) )
+      {
+        $sql .= " ENGINE=" . $table_options['engine'];
+      }
+
+      if ( isset( $table_options['auto_increment'] ) )
+      {
+        $sql .= " AUTO_INCREMENT=" . $table_options['auto_increment'];
+      }
+
+      if ( isset( $table_options['character_set'] ) )
+      {
+        $sql .= " CHARACTER SET=" . $table_options['character_set'];
+      }
+
+      if ( isset( $table_options['comment'] ) )
+      {
+        $sql .= " COMMENT '" . str_replace("'", "''", $table_options['comment']) . "'";
+      }
+
+      $sql .= ";";
+    }
 
 		return $this->run_query($sql);
 	}

--- a/classes/Migration.php
+++ b/classes/Migration.php
@@ -88,6 +88,9 @@ class Migration
 	 * 				'date' => 'date',
 	 * 				'content' => 'text'
 	 * 			),
+	 * 			array (
+	 * 				'engine' => 'InnoDB',
+	 * 			)
 	 * 		)
 	 *
 	 * @param	string   Name of the table to be created
@@ -96,10 +99,10 @@ class Migration
 	 *                   Will be set to auto_increment, serial, etc.
 	 * @return	boolean
 	 */
-	public function create_table($table_name, $fields, $primary_key = TRUE)
+	public function create_table($table_name, $fields, $primary_key = TRUE, $table_options = FALSE)
 	{
 		$this->log("Creating table '$table_name'...");
-		$ret = $this->driver->create_table($table_name, $fields, $primary_key);
+		$ret = $this->driver->create_table($table_name, $fields, $primary_key, $table_options);
 		$this->log("DONE<br />");
 		return $ret;
 	}


### PR DESCRIPTION
There are some very useful options for specific drivers at the table level.  The most obvious in MySQL is ENGINE.

This patch adds an optional parameter to create_table which adds support for several MySQL specific table options.  Others could easily be added.
